### PR TITLE
Fix signing by changing the product type

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Sinter requires a configuration file to be present at `/etc/sinter/config.json`.
 
 After building, from the build directory (`cd` to the build directory seen in the `--destination` output of the `xcodebuild` step):
 
-`sudo Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.systemextension`
+`sudo ./Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon`
 
 ## License
 

--- a/Sinter.xcodeproj/project.pbxproj
+++ b/Sinter.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		D20F58822450DC880070C21C /* LocalDecisionManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2BDB3E3244102080027C57F /* LocalDecisionManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D20F58832450DC880070C21C /* SyncServerDecisionManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2513BB52440D6E400002645 /* SyncServerDecisionManager.framework */; };
 		D20F58842450DC880070C21C /* SyncServerDecisionManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2513BB52440D6E400002645 /* SyncServerDecisionManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D20F58872450DDBF0070C21C /* com.trailofbits.sinter.system-extension. in CopyFiles */ = {isa = PBXBuildFile; fileRef = D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D20F58872450DDBF0070C21C /* com.trailofbits.sinter.daemon.systemextension in CopyFiles */ = {isa = PBXBuildFile; fileRef = D20F586D2450DC090070C21C /* com.trailofbits.sinter.daemon.systemextension */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D24B4A522448AEC900958F82 /* NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D24B4A3F2448A73200958F82 /* NotificationService.framework */; };
 		D24B4A532448AEC900958F82 /* NotificationService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D24B4A3F2448A73200958F82 /* NotificationService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2513B67244073A900002645 /* libbsm.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D2513B61244073A300002645 /* libbsm.tbd */; };
@@ -156,7 +156,7 @@
 			dstPath = "$(SYSTEM_EXTENSIONS_FOLDER_PATH)";
 			dstSubfolderSpec = 16;
 			files = (
-				D20F58872450DDBF0070C21C /* com.trailofbits.sinter.system-extension. in CopyFiles */,
+				D20F58872450DDBF0070C21C /* com.trailofbits.sinter.daemon.systemextension in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -196,7 +196,7 @@
 		D20F58502450DA380070C21C /* entitlements.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = entitlements.plist; sourceTree = "<group>"; };
 		D20F58612450DA800070C21C /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D20F58632450DA8E0070C21C /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
-		D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */ = {isa = PBXFileReference; explicitFileType = "wrapper.system-extension"; includeInIndex = 0; path = "com.trailofbits.sinter.system-extension."; sourceTree = BUILT_PRODUCTS_DIR; };
+		D20F586D2450DC090070C21C /* com.trailofbits.sinter.daemon.systemextension */ = {isa = PBXFileReference; explicitFileType = "wrapper.system-extension"; includeInIndex = 0; path = com.trailofbits.sinter.daemon.systemextension; sourceTree = BUILT_PRODUCTS_DIR; };
 		D20F586F2450DC090070C21C /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D20F58752450DC510070C21C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D20F58762450DC510070C21C /* entitlements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = entitlements.plist; sourceTree = "<group>"; };
@@ -361,7 +361,7 @@
 			children = (
 				D2578410243F602F0020BC32 /* Sinter.app */,
 				D20F58412450DA370070C21C /* notification-server.xpc */,
-				D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */,
+				D20F586D2450DC090070C21C /* com.trailofbits.sinter.daemon.systemextension */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -478,7 +478,7 @@
 			);
 			name = "system-extension";
 			productName = "system-extension";
-			productReference = D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */;
+			productReference = D20F586D2450DC090070C21C /* com.trailofbits.sinter.daemon.systemextension */;
 			productType = "com.apple.product-type.system-extension";
 		};
 		D257840F243F602E0020BC32 /* Sinter */ = {
@@ -522,7 +522,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */;
+			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -745,13 +745,10 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../../../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
-				PRODUCT_MODULE_NAME = "com.trailofbits.sinter.system-extension";
-				PRODUCT_NAME = "com.trailofbits.sinter.system-extension";
 				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
 				SWIFT_VERSION = 5.0;
-				WRAPPER_EXTENSION = "";
 			};
 			name = Debug;
 		};
@@ -765,13 +762,10 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../../../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
-				PRODUCT_MODULE_NAME = "com.trailofbits.sinter.system-extension";
-				PRODUCT_NAME = "com.trailofbits.sinter.system-extension";
 				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
 				SWIFT_VERSION = 5.0;
-				WRAPPER_EXTENSION = "";
 			};
 			name = Release;
 		};
@@ -957,7 +951,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */ = {
+		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D2578421243F60350020BC32 /* Debug */,

--- a/Sinter.xcodeproj/project.pbxproj
+++ b/Sinter.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		D20F58822450DC880070C21C /* LocalDecisionManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2BDB3E3244102080027C57F /* LocalDecisionManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D20F58832450DC880070C21C /* SyncServerDecisionManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2513BB52440D6E400002645 /* SyncServerDecisionManager.framework */; };
 		D20F58842450DC880070C21C /* SyncServerDecisionManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2513BB52440D6E400002645 /* SyncServerDecisionManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D20F58872450DDBF0070C21C /* com.trailofbits.sinter.systemextension in CopyFiles */ = {isa = PBXBuildFile; fileRef = D20F586D2450DC090070C21C /* com.trailofbits.sinter.systemextension */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D20F58872450DDBF0070C21C /* com.trailofbits.sinter.system-extension. in CopyFiles */ = {isa = PBXBuildFile; fileRef = D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D24B4A522448AEC900958F82 /* NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D24B4A3F2448A73200958F82 /* NotificationService.framework */; };
 		D24B4A532448AEC900958F82 /* NotificationService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D24B4A3F2448A73200958F82 /* NotificationService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2513B67244073A900002645 /* libbsm.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D2513B61244073A300002645 /* libbsm.tbd */; };
@@ -156,7 +156,7 @@
 			dstPath = "$(SYSTEM_EXTENSIONS_FOLDER_PATH)";
 			dstSubfolderSpec = 16;
 			files = (
-				D20F58872450DDBF0070C21C /* com.trailofbits.sinter.systemextension in CopyFiles */,
+				D20F58872450DDBF0070C21C /* com.trailofbits.sinter.system-extension. in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -196,7 +196,7 @@
 		D20F58502450DA380070C21C /* entitlements.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = entitlements.plist; sourceTree = "<group>"; };
 		D20F58612450DA800070C21C /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D20F58632450DA8E0070C21C /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
-		D20F586D2450DC090070C21C /* com.trailofbits.sinter.systemextension */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = com.trailofbits.sinter.systemextension; sourceTree = BUILT_PRODUCTS_DIR; };
+		D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */ = {isa = PBXFileReference; explicitFileType = "wrapper.system-extension"; includeInIndex = 0; path = "com.trailofbits.sinter.system-extension."; sourceTree = BUILT_PRODUCTS_DIR; };
 		D20F586F2450DC090070C21C /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D20F58752450DC510070C21C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D20F58762450DC510070C21C /* entitlements.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = entitlements.plist; sourceTree = "<group>"; };
@@ -361,7 +361,7 @@
 			children = (
 				D2578410243F602F0020BC32 /* Sinter.app */,
 				D20F58412450DA370070C21C /* notification-server.xpc */,
-				D20F586D2450DC090070C21C /* com.trailofbits.sinter.systemextension */,
+				D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -478,8 +478,8 @@
 			);
 			name = "system-extension";
 			productName = "system-extension";
-			productReference = D20F586D2450DC090070C21C /* com.trailofbits.sinter.systemextension */;
-			productType = "com.apple.product-type.tool";
+			productReference = D20F586D2450DC090070C21C /* com.trailofbits.sinter.system-extension. */;
+			productType = "com.apple.product-type.system-extension";
 		};
 		D257840F243F602E0020BC32 /* Sinter */ = {
 			isa = PBXNativeTarget;
@@ -522,7 +522,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */;
+			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -739,17 +739,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Sinter/system-extension/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 44WTB9L362;
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.trailofbits.sinter.system-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
 				PRODUCT_MODULE_NAME = "com.trailofbits.sinter.system-extension";
-				PRODUCT_NAME = com.trailofbits.sinter.systemextension;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_NAME = "com.trailofbits.sinter.system-extension";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = "";
 			};
@@ -759,17 +759,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Sinter/system-extension/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 44WTB9L362;
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.trailofbits.sinter.system-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
 				PRODUCT_MODULE_NAME = "com.trailofbits.sinter.system-extension";
-				PRODUCT_NAME = com.trailofbits.sinter.systemextension;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PRODUCT_NAME = "com.trailofbits.sinter.system-extension";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = "";
 			};
@@ -957,7 +957,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */ = {
+		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D2578421243F60350020BC32 /* Debug */,

--- a/Sinter.xcodeproj/project.pbxproj
+++ b/Sinter.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */;
+			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -745,7 +745,7 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
 				PRODUCT_MODULE_NAME = "com.trailofbits.sinter.system-extension";
 				PRODUCT_NAME = "com.trailofbits.sinter.system-extension";
@@ -765,7 +765,7 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
 				PRODUCT_MODULE_NAME = "com.trailofbits.sinter.system-extension";
 				PRODUCT_NAME = "com.trailofbits.sinter.system-extension";
@@ -957,7 +957,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */ = {
+		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D2578421243F60350020BC32 /* Debug */,

--- a/Sinter/application/entitlements.plist
+++ b/Sinter/application/entitlements.plist
@@ -2,7 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.endpoint-security.client</key>
+	<true/>
 	<key>com.apple.developer.system-extension.install</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.trailofbits.sinter</string>
+	</array>
 </dict>
 </plist>

--- a/Sinter/notification-server/entitlements.plist
+++ b/Sinter/notification-server/entitlements.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.trailofbits.sinter</string>
+	</array>
+</dict>
 </plist>

--- a/Sinter/system-extension/Info.plist
+++ b/Sinter/system-extension/Info.plist
@@ -26,8 +26,6 @@
 	<string>Copyright © 2020 Trail of Bits. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSSupportsAutomaticTermination</key>
 	<true/>
 	<key>NSSupportsSuddenTermination</key>

--- a/Sinter/system-extension/entitlements.plist
+++ b/Sinter/system-extension/entitlements.plist
@@ -2,7 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.developer.endpoint-security.client</key>
-    <true/>
+	<key>com.apple.developer.endpoint-security.client</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.trailofbits.sinter</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This is the fix, I did it with vim but there was probably a way to do it
in the UI. This lets us sign the extension and apply a provisioning
profile.
-			productType = "com.apple.product-type.tool";
+			productType = "com.apple.product-type.system-extension";

I also added appgroups to everything, i'm pretty sure they'll be needed.