### PR TITLE
Additional packaging fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sinter is a 100% user-mode endpoint security agent for macOS 10.15 and above, wr
 
 ## How to Run (if built from source)
 
-Sinter uses the Endpoint Security API in macOS 10.15 and above, meaning it must be code-signed with an Apple-issued signing certificate and provisioning profile that includes the Endpoint Security entitlement, which requires a manual application to Apple for approval. If you cannot sign with such a certificate, then you must disable SIP if you want to run Sinter built from source. To disable SIP (*not recommended except on a test system*):
+Sinter uses the Endpoint Security API in macOS 10.15 and above, meaning it must be code-signed with an Apple-issued "Distribution" signing certificate and provisioning profile that includes the Endpoint Security entitlement, which requires a manual application to Apple for approval. If you cannot sign with such a certificate, then you must disable SIP if you want to run Sinter built from source. To disable SIP (*not recommended except on a test system*):
 
 Schedule a Recovery Mode reboot:
 
@@ -32,7 +32,7 @@ Finally, to run Sinter, do not double-click the `Sinter` app bundle in Finder. R
 
 `$ sudo Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.systemextension`
 
-In this version, it outputs events to the command line and to text-based log files under `/var/db/sinter/`.
+In this version, it outputs events to stdout.
 
 ## How to Build
 
@@ -52,13 +52,13 @@ With the Xcode project open, enter the top-level project settings, and navigate 
 
 ### Apply for EndpointSecurity entitltements for your code-signing identity (optional, required for distribution)
 
-To be able to distribute a macOS application that uses the `EndpointSecurity` API, as Sinter does, requires building and signing with a certificate from an Apple Developer Account that has been approved for the `EndpointSecurity` entitlement. Note that only a Team Account *owner* can apply for this entitlement.
+To be able to distribute a macOS application that uses the `EndpointSecurity` API, as Sinter does, requires building and signing with a Distribution certificate from an Apple Developer Account that has been approved for the `EndpointSecurity` entitlement. Note that only a Team Account *owner* can apply for this entitlement.
 
 ### Build with Xcode at the command line
 
 From the Sinter directory:
 
-`$ xcodebuild -scheme Sinter`
+`$ xcodebuild -scheme Sinter -configuration Release`
 
 Optional: you may need to set the command-line tools to the full Xcode, first, then try the above command again:
 
@@ -71,6 +71,8 @@ Sinter requires a configuration file to be present at `/etc/sinter/config.json`.
 After building, from the build directory (`cd` to the build directory seen in the `--destination` output of the `xcodebuild` step):
 
 `sudo ./Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon`
+
+*In order to be launched as a LaunchDaemon*, "Full Disk Access" must also be enabled on `Sinter.app`. Do this by opening System Preferences, Security, Privacy tab, Full Disk Access. Check the item for `Sinter.app`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Finally, to run Sinter, do not double-click the `Sinter` app bundle in Finder. R
 
 `$ sudo Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.systemextension`
 
-In this version, it outputs events to stdout.
+In this version, it outputs events to stdout. When run as a LaunchDaemon, which is the default install method, it includes a configuration that also redirects stdout and stderr to logs in `/var/db/sinter/`. Logs are updated every 2 minutes. View `Console.app` for live logging.
 
 ## How to Build
 

--- a/Sinter.xcodeproj/project.pbxproj
+++ b/Sinter.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */;
+			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -688,7 +688,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Sinter/notification-server/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -703,7 +703,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.trailofbits.sinter.notification-server";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (App Distribution)";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = xpc;
 			};
@@ -714,7 +714,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Sinter/notification-server/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -729,7 +729,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.trailofbits.sinter.notification-server";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (App Distribution)";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = xpc;
 			};
@@ -739,7 +739,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Sinter/system-extension/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 44WTB9L362;
 				ENABLE_HARDENED_RUNTIME = NO;
@@ -747,7 +747,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../../../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (App Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -756,7 +756,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Sinter/system-extension/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 44WTB9L362;
 				ENABLE_HARDENED_RUNTIME = NO;
@@ -764,7 +764,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../../../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (App Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -887,7 +887,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sinter/application/entitlements.plist;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -901,7 +901,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter development profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter (Application Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -911,7 +911,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sinter/application/entitlements.plist;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -925,7 +925,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter development profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter (Application Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -951,7 +951,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */ = {
+		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D2578421243F60350020BC32 /* Debug */,

--- a/packaging/macOS-x64/build-macos-x64.sh
+++ b/packaging/macOS-x64/build-macos-x64.sh
@@ -11,7 +11,6 @@ function printUsage() {
   echo
   echo -e "\033[1mExample::\033[0m"
   echo "$0 Sinter 2.6.0"
-
 }
 
 #Argument validation
@@ -107,9 +106,10 @@ copyBuildDirectory() {
     rm -rf ${TARGET_DIRECTORY}/darwinpkg
     mkdir -p ${TARGET_DIRECTORY}/darwinpkg
 
-    mkdir -p ${TARGET_DIRECTORY}/darwinpkg/Applications/${PRODUCT}
-    cp -a ./application/* ${TARGET_DIRECTORY}/darwinpkg/Applications/${PRODUCT}
-    chmod -R 755 ${TARGET_DIRECTORY}/darwinpkg/Applications/${PRODUCT}
+    # Install path must be /Applications/Sinter.app in order to meet SystemExtension requirements
+    mkdir -p ${TARGET_DIRECTORY}/darwinpkg/Applications/
+    cp -a ./application/* ${TARGET_DIRECTORY}/darwinpkg/Applications/
+    chmod -R 755 ${TARGET_DIRECTORY}/darwinpkg/Applications/
 
     mkdir -p ${TARGET_DIRECTORY}/darwinpkg/etc/sinter
     cp -a ./config/config.json.example ${TARGET_DIRECTORY}/darwinpkg/etc/sinter/config.json
@@ -174,9 +174,11 @@ function createInstaller() {
 }
 
 function createUninstaller(){
-    cp darwin/Resources/uninstall.sh ${TARGET_DIRECTORY}/darwinpkg/Applications/${PRODUCT}/
-    sed -i '' -e "s/__VERSION__/${VERSION}/g" "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}/uninstall.sh"
-    sed -i '' -e "s/__PRODUCT__/${PRODUCT}/g" "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}/uninstall.sh"
+#  If we want to ship an uninstaller script later, uncomment these lines.
+#    cp darwin/Resources/uninstall.sh ${TARGET_DIRECTORY}/darwinpkg/Applications/${PRODUCT}/
+#    sed -i '' -e "s/__VERSION__/${VERSION}/g" "${TARGET_DIRECTORY}/darwinpkg/Applications/${PRODUCT}/uninstall.sh"
+#    sed -i '' -e "s/__PRODUCT__/${PRODUCT}/g" "${TARGET_DIRECTORY}/darwinpkg/Applications/${PRODUCT}/uninstall.sh"
+    log_info "Skipping uninstaller script inclusion."
 }
 
 #Main script

--- a/packaging/macOS-x64/darwin/Resources/conclusion.html
+++ b/packaging/macOS-x64/darwin/Resources/conclusion.html
@@ -8,13 +8,13 @@
   <meta name="CocoaVersion" content="1894.4">
   <style type="text/css">
     p.p2 {margin: 0.0px 0.0px 11.0px 0.0px; font: 11.0px Helvetica; color: #020202; -webkit-text-stroke: #020202}
-    p.p4 {margin: 0.0px 0.0px 0.0px 0.0px; font: 11.0px Menlo; color: #636b69; -webkit-text-stroke: #636b69}
+    p.p4 {margin: 0.0px 0.0px 0.0px 0.0px; font: 11.0px Menlo; color: #505856; -webkit-text-stroke: #505856}
     p.p5 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Helvetica; color: #000000; -webkit-text-stroke: #000000}
-    p.p7 {margin: 0.0px 0.0px 11.0px 0.0px; font: 11.0px Menlo; color: #636b69; -webkit-text-stroke: #636b69}
-    p.p8 {margin: 0.0px 0.0px 10.0px 0.0px; font: 10.0px Helvetica; color: #636b69; -webkit-text-stroke: #636b69}
+    p.p7 {margin: 0.0px 0.0px 11.0px 0.0px; font: 11.0px Menlo; color: #505856; -webkit-text-stroke: #505856}
+    p.p8 {margin: 0.0px 0.0px 10.0px 0.0px; font: 10.0px Helvetica; color: #505856; -webkit-text-stroke: #505856}
     li.li6 {margin: 0.0px 0.0px 0.0px 0.0px; font: 11.0px Helvetica; color: #0000e9; -webkit-text-stroke: #000000}
     span.s1 {font-kerning: none}
-    span.s2 {font-kerning: none; color: #866412; -webkit-text-stroke: 0px #866412}
+    span.s2 {font-kerning: none; color: #725210; -webkit-text-stroke: 0px #725210}
     span.s3 {-webkit-text-stroke: 0px #000000}
     span.s4 {text-decoration: underline ; font-kerning: none}
     span.s5 {font: 11.0px Helvetica; font-kerning: none; color: #020202; -webkit-text-stroke: 0px #020202}
@@ -27,7 +27,7 @@
 <p class="p2"><span class="s1">Thank you for installing the Sinter Endpoint Agent.</span></p>
 <h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 10.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Run Sinter Agent Manually (optional; should be running already after install)</b></span></h5>
 <p class="p2"><span class="s1">Open a new terminal and run the following command to get started with Sinter:</span></p>
-<p class="p4"><span class="s2">  $ </span><span class="s1">sudo Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon</span></p>
+<p class="p4"><span class="s2">  $ </span><span class="s1">sudo /Applications/Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon</span></p>
 <p class="p5"><span class="s1"><br>
 </span></p>
 <h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 10.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Resources</b></span></h5>

--- a/packaging/macOS-x64/darwin/Resources/conclusion.html
+++ b/packaging/macOS-x64/darwin/Resources/conclusion.html
@@ -8,42 +8,42 @@
   <meta name="CocoaVersion" content="1894.4">
   <style type="text/css">
     p.p2 {margin: 0.0px 0.0px 11.0px 0.0px; font: 11.0px Helvetica; color: #020202; -webkit-text-stroke: #020202}
-    p.p4 {margin: 0.0px 0.0px 0.0px 0.0px; font: 11.0px Menlo; color: #505856; -webkit-text-stroke: #505856}
-    p.p5 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Helvetica; color: #000000; -webkit-text-stroke: #000000}
-    p.p7 {margin: 0.0px 0.0px 11.0px 0.0px; font: 11.0px Menlo; color: #505856; -webkit-text-stroke: #505856}
-    p.p8 {margin: 0.0px 0.0px 10.0px 0.0px; font: 10.0px Helvetica; color: #505856; -webkit-text-stroke: #505856}
+    p.p5 {margin: 0.0px 0.0px 0.0px 0.0px; font: 11.0px Menlo; color: #3f4644; -webkit-text-stroke: #3f4644}
+    p.p7 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Helvetica; color: #000000; -webkit-text-stroke: #000000; min-height: 14.0px}
+    p.p8 {margin: 0.0px 0.0px 11.0px 0.0px; font: 11.0px Menlo; color: #3f4644; -webkit-text-stroke: #3f4644}
+    p.p9 {margin: 0.0px 0.0px 10.0px 0.0px; font: 10.0px Helvetica; color: #3f4644; -webkit-text-stroke: #3f4644}
     li.li6 {margin: 0.0px 0.0px 0.0px 0.0px; font: 11.0px Helvetica; color: #0000e9; -webkit-text-stroke: #000000}
     span.s1 {font-kerning: none}
-    span.s2 {font-kerning: none; color: #725210; -webkit-text-stroke: 0px #725210}
-    span.s3 {-webkit-text-stroke: 0px #000000}
-    span.s4 {text-decoration: underline ; font-kerning: none}
-    span.s5 {font: 11.0px Helvetica; font-kerning: none; color: #020202; -webkit-text-stroke: 0px #020202}
-    span.s6 {font: 12.0px Helvetica; font-kerning: none; color: #000000; -webkit-text-stroke: 0px #000000}
+    span.s2 {font-kerning: none; color: #5e410e; -webkit-text-stroke: 0px #5e410e}
+    span.s3 {font: 12.0px Helvetica; font-kerning: none; color: #000000; -webkit-text-stroke: 0px #000000}
+    span.s4 {-webkit-text-stroke: 0px #000000}
+    span.s5 {text-decoration: underline ; font-kerning: none}
+    span.s6 {font: 11.0px Helvetica; font-kerning: none; color: #020202; -webkit-text-stroke: 0px #020202}
     ul.ul1 {list-style-type: disc}
   </style>
 </head>
 <body>
 <h3 style="margin: 0.0px 0.0px 14.0px 0.0px; font: 14.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Sinter Endpoint Agent</b></span></h3>
 <p class="p2"><span class="s1">Thank you for installing the Sinter Endpoint Agent.</span></p>
-<h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 10.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Run Sinter Agent Manually (optional; should be running already after install)</b></span></h5>
+<h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 10.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Important! Enable Sinter.app in Full Disk Access</b></span></h5>
+<h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 11.0px Helvetica; color: #020202; -webkit-text-stroke: #020202"><span class="s1">Open macOS System Preferences and navigate to the Privacy tab. Under Full Disk Access, check the box for Sinter.app.</span></h5>
+<h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 10.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Run Sinter Agent Manually (optional; should be running as a LaunchDaemon after install)</b></span></h5>
 <p class="p2"><span class="s1">Open a new terminal and run the following command to get started with Sinter:</span></p>
-<p class="p4"><span class="s2">  $ </span><span class="s1">sudo /Applications/Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon</span></p>
-<p class="p5"><span class="s1"><br>
+<p class="p5"><span class="s2">  $ </span><span class="s1">sudo /Applications/Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon</span><span class="s3"><br>
 </span></p>
 <h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 10.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Resources</b></span></h5>
 <p class="p2"><span class="s1">Visit the following links for additional information.</span></p>
 <ul class="ul1">
-  <li class="li6"><span class="s3"><a href="https://github.com/trailofbits/sinter/blob/master/README.md"><span class="s4">Documentation</span></a></span></li>
+  <li class="li6"><span class="s4"><a href="https://github.com/trailofbits/sinter/blob/master/README.md"><span class="s5">Documentation</span></a></span></li>
 </ul>
-<p class="p5"><span class="s1"><br>
-</span></p>
+<p class="p7"><span class="s1"></span><br></p>
 <h5 style="margin: 0.0px 0.0px 16.6px 0.0px; font: 10.0px Helvetica; color: #000000; -webkit-text-stroke: #000000"><span class="s1"><b>Uninstalling Sinter</b></span></h5>
-<p class="p7"><span class="s5">Run the following command to uninstall Sinter. <br>
+<p class="p8"><span class="s6">Run the following command to uninstall Sinter. <br>
 </span><span class="s2"><br>
   $ </span><span class="s1">sudo /bin/launchctl unload /Library/LaunchDaemons/com.trailofbits.sinter.plist</span></p>
-<p class="p7"><span class="s2"><span class="Apple-converted-space">  </span>$ </span><span class="s1">rm -f /Library/LaunchDaemons/com.trailofbits.sinter.plist</span></p>
-<p class="p2"><span class="s1">Then, drag /Applications/Sinter/ to the Trash.</span><span class="s6"><br>
+<p class="p8"><span class="s2"><span class="Apple-converted-space">  </span>$ </span><span class="s1">rm -f /Library/LaunchDaemons/com.trailofbits.sinter.plist</span></p>
+<p class="p2"><span class="s1">Then, drag /Applications/Sinter/ to the Trash.</span><span class="s3"><br>
 </span></p>
-<p class="p8"><span class="s1">Copyright © 2020 Trail of Bits. All rights reserved. Sinter and its use are subject to a license agreement and to copyright, trademark patent and/or other laws.</span></p>
+<p class="p9"><span class="s1">Copyright © 2020 Trail of Bits. All rights reserved. Sinter and its use are subject to a license agreement and to copyright, trademark patent and/or other laws.</span></p>
 </body>
 </html>

--- a/packaging/macOS-x64/darwin/Resources/uninstall.sh
+++ b/packaging/macOS-x64/darwin/Resources/uninstall.sh
@@ -42,7 +42,7 @@ VERSION=__VERSION__
 PRODUCT=__PRODUCT__
 
 echo "Application uninstalling process started"
-# remove link to shorcut file
+# remove application bundle
 find "/Applications/" -name "__PRODUCT__" | xargs rm
 if [ $? -eq 0 ]
 then
@@ -51,7 +51,7 @@ else
   echo "[1/3] [ERROR] Could not delete Application" >&2
 fi
 
-#forget from pkgutil
+# forget from pkgutil
 pkgutil --forget "org.$PRODUCT.$VERSION" > /dev/null 2>&1
 if [ $? -eq 0 ]
 then
@@ -60,7 +60,7 @@ else
   echo "[2/3] [ERROR] Could not delete application informations" >&2
 fi
 
-#remove launchd item
+# remove launchd item
 /bin/launchctl unload /Library/LaunchDaemons/com.trailofbits.sinter.plist && rm -f /Library/LaunchDaemons/com.trailofbits.sinter.plist
 if [ $? -eq 0 ]
 then

--- a/packaging/macOS-x64/plist/com.trailofbits.sinter.plist
+++ b/packaging/macOS-x64/plist/com.trailofbits.sinter.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>StandardErrorPath</key>
+	<string>/var/db/sinter/err.log</string>
+	<key>StandardOutPath</key>
+	<string>/var/db/sinter/sinter.log</string>
 	<key>Label</key>
 	<string>com.trailofbits.sinter</string>
 	<key>ProgramArguments</key>

--- a/packaging/macOS-x64/plist/com.trailofbits.sinter.plist
+++ b/packaging/macOS-x64/plist/com.trailofbits.sinter.plist
@@ -6,7 +6,7 @@
 	<string>com.trailofbits.sinter</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Applications/Sinter/Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon</string>
+		<string>/Applications/Sinter.app/Contents/Library/SystemExtensions/com.trailofbits.sinter.daemon.systemextension/Contents/MacOS/com.trailofbits.sinter.daemon</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
Moved the install destination of Sinter from /Applications/Sinter/Sinter.app to /Applications/Sinter.app to fulfill a requirement of valid SystemExtension paths. And removed the inclusion of the uninstaller shell script. Updated the plist for the launchd item to reflect the path change, but also to redirect stdout to a local filesystem log for ease of log collection in this version of Sinter.

Determined that running requires Sinter.app be granted Full Disk Access in the TCC entitlements, which is now noted with additional instructions in the documentation.

Also changed the Xcode project signing identity to be Developer ID (i.e. for Distribution signing).