### PR TITLE
Fixes for notarization

### DIFF
--- a/Sinter.xcodeproj/project.pbxproj
+++ b/Sinter.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */;
+			buildConfigurationList = D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -688,12 +688,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Sinter/notification-server/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 44WTB9L362;
-				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -701,9 +701,10 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.trailofbits.sinter.notification-server";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (App Distribution)";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = xpc;
 			};
@@ -714,12 +715,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Sinter/notification-server/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 44WTB9L362;
-				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -727,9 +728,10 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.trailofbits.sinter.notification-server";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Notification Server (App Distribution)";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = xpc;
 			};
@@ -739,15 +741,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Sinter/system-extension/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 44WTB9L362;
-				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../../../../Frameworks";
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (App Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -756,15 +759,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Sinter/system-extension/entitlements.plist";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 44WTB9L362;
-				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
 				EXECUTABLE_EXTENSION = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sinter/notification-server/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../../../../Frameworks";
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter.daemon;
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (dev)";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter Daemon (App Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -801,8 +805,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 44WTB9L362;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -861,8 +869,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 44WTB9L362;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -887,7 +899,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sinter/application/entitlements.plist;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -899,9 +911,10 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter development profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter (Application Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -911,7 +924,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sinter/application/entitlements.plist;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -923,9 +936,10 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trailofbits.sinter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Sinter development profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Sinter (Application Distribution)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -951,7 +965,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "sinter" */ = {
+		D257840B243F602E0020BC32 /* Build configuration list for PBXProject "Sinter" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D2578421243F60350020BC32 /* Debug */,

--- a/Sinter.xcodeproj/project.pbxproj
+++ b/Sinter.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Sinter/notification-server/entitlements.plist";
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -760,6 +761,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Sinter/system-extension/entitlements.plist";
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 44WTB9L362;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -925,6 +927,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sinter/application/entitlements.plist;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "";

--- a/components/AuthorizationManager/AuthorizationManager.xcodeproj/project.pbxproj
+++ b/components/AuthorizationManager/AuthorizationManager.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		D20F58CC2450E24F0070C21C /* SignatureDatabaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20F58CB2450E24F0070C21C /* SignatureDatabaseInterface.swift */; };
 		D20F58CE2450E2640070C21C /* AuthorizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20F58CD2450E2640070C21C /* AuthorizationManager.swift */; };
 		D20F58D52450E4300070C21C /* NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58D42450E4300070C21C /* NotificationService.framework */; };
-		D20F58D62450E4300070C21C /* NotificationService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58D42450E4300070C21C /* NotificationService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,7 +26,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D20F58D62450E4300070C21C /* NotificationService.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/components/EndpointSecurityClient/EndpointSecurityClient.xcodeproj/project.pbxproj
+++ b/components/EndpointSecurityClient/EndpointSecurityClient.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		D20F58E12450E4740070C21C /* AuthorizationManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58E02450E4740070C21C /* AuthorizationManager.framework */; };
-		D20F58E22450E4740070C21C /* AuthorizationManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58E02450E4740070C21C /* AuthorizationManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2513B602440739200002645 /* libbsm.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D2513B5F2440738C00002645 /* libbsm.tbd */; };
 		D257850A243F77DC0020BC32 /* EndpointSecurityClient.h in Headers */ = {isa = PBXBuildFile; fileRef = D2578508243F77DC0020BC32 /* EndpointSecurityClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2578524243F78580020BC32 /* EndpointSecurityClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2578523243F78580020BC32 /* EndpointSecurityClient.swift */; };
@@ -23,7 +22,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D20F58E22450E4740070C21C /* AuthorizationManager.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/components/FilesystemLogger/FilesystemLogger.xcodeproj/project.pbxproj
+++ b/components/FilesystemLogger/FilesystemLogger.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		D20F58E92450E4800070C21C /* AuthorizationManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58E82450E4800070C21C /* AuthorizationManager.framework */; };
-		D20F58EA2450E4800070C21C /* AuthorizationManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58E82450E4800070C21C /* AuthorizationManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D25784B5243F6FE60020BC32 /* FilesystemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = D25784B3243F6FE60020BC32 /* FilesystemLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D25784C2243F700F0020BC32 /* FilesystemLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25784C1243F700F0020BC32 /* FilesystemLogger.swift */; };
 /* End PBXBuildFile section */
@@ -20,7 +19,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D20F58EA2450E4800070C21C /* AuthorizationManager.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/components/InMemorySignatureDatabase/InMemorySignatureDatabase.xcodeproj/project.pbxproj
+++ b/components/InMemorySignatureDatabase/InMemorySignatureDatabase.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		D20F58DD2450E45E0070C21C /* AuthorizationManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58DC2450E45E0070C21C /* AuthorizationManager.framework */; };
-		D20F58DE2450E45E0070C21C /* AuthorizationManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58DC2450E45E0070C21C /* AuthorizationManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2513B792440BE7100002645 /* InMemorySignatureDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = D2513B772440BE7100002645 /* InMemorySignatureDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2513B942440BF2400002645 /* InMemorySignatureDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2513B932440BF2400002645 /* InMemorySignatureDatabase.swift */; };
 		D2513B962440BFA000002645 /* CodeSignatureChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2513B952440BFA000002645 /* CodeSignatureChecker.swift */; };
@@ -21,7 +20,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D20F58DE2450E45E0070C21C /* AuthorizationManager.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/components/JSONConfiguration/JSONConfiguration.xcodeproj/project.pbxproj
+++ b/components/JSONConfiguration/JSONConfiguration.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		D20F58E52450E47B0070C21C /* AuthorizationManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58E42450E47B0070C21C /* AuthorizationManager.framework */; };
-		D20F58E62450E47B0070C21C /* AuthorizationManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58E42450E47B0070C21C /* AuthorizationManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D25784E3243F75540020BC32 /* JSONConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = D25784E1243F75540020BC32 /* JSONConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D25784F8243F75AF0020BC32 /* JSONConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25784F7243F75AF0020BC32 /* JSONConfiguration.swift */; };
 /* End PBXBuildFile section */
@@ -20,7 +19,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D20F58E62450E47B0070C21C /* AuthorizationManager.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/components/LocalDecisionManager/LocalDecisionManager.xcodeproj/project.pbxproj
+++ b/components/LocalDecisionManager/LocalDecisionManager.xcodeproj/project.pbxproj
@@ -8,9 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D24B4A552448B88400958F82 /* NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D24B4A542448B88400958F82 /* NotificationService.framework */; };
-		D24B4A562448B88400958F82 /* NotificationService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D24B4A542448B88400958F82 /* NotificationService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2A3A6AE24534AE300CF24FB /* AuthorizationManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2A3A6AD24534AE300CF24FB /* AuthorizationManager.framework */; };
-		D2A3A6AF24534AE300CF24FB /* AuthorizationManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2A3A6AD24534AE300CF24FB /* AuthorizationManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2BDB3D3244102070027C57F /* LocalDecisionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = D2BDB3D1244102070027C57F /* LocalDecisionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2BDB3E72441021D0027C57F /* LocalDecisionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDB3E62441021D0027C57F /* LocalDecisionManager.swift */; };
 		D2BDB3EE244104F00027C57F /* JSONRuleDatabaseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDB3ED244104F00027C57F /* JSONRuleDatabaseParser.swift */; };
@@ -23,8 +21,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D2A3A6AF24534AE300CF24FB /* AuthorizationManager.framework in Embed Frameworks */,
-				D24B4A562448B88400958F82 /* NotificationService.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/components/SyncServerDecisionManager/SyncServerDecisionManager.xcodeproj/project.pbxproj
+++ b/components/SyncServerDecisionManager/SyncServerDecisionManager.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		D20F58D92450E4560070C21C /* AuthorizationManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58D82450E4560070C21C /* AuthorizationManager.framework */; };
-		D20F58DA2450E4560070C21C /* AuthorizationManager.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D20F58D82450E4560070C21C /* AuthorizationManager.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D2513BAA2440D6E300002645 /* SyncServerDecisionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = D2513BA82440D6E300002645 /* SyncServerDecisionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2513BC22440D72100002645 /* SyncServerDecisionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2513BC12440D72100002645 /* SyncServerDecisionManager.swift */; };
 		D2513BC42440D73E00002645 /* JSONRuleDatabaseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2513BC32440D73E00002645 /* JSONRuleDatabaseParser.swift */; };
@@ -21,7 +20,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D20F58DA2450E4560070C21C /* AuthorizationManager.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
As of this morning the Sinter.app passes Apple notarization, and the Sinter daemon runs successfully on a SIP-enabled macOS 10.15.

We will do a little more testing to ensure no problems and then merge this branch and produce a pkg installer for testing.