### PR TITLE
Add client_mode config var with discrete MONITOR and LOCKDOWN modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ Sinter is a 100% user-mode endpoint security agent for macOS 10.15 and above, wr
 
 (Work in progress)
 - MONITOR mode: captures process execution events and records them to a log on the local filesystem.
-- Process execution whitelisting and blacklisting
- - by certificate Team ID
- - by hash
- - by executable file path
-- Sync server support (compatible with the Moroz sync-server for Santa clients)
+- LOCKDOWN mode: like MONITOR mode, but additionally blocks processes with missing or invalid signatures.
+
+- While in either mode:
+ - Process execution whitelisting and blacklisting
+  - by certificate Team ID
+  - by hash
+  - by executable file path
+ - Sync server support (compatible with the Moroz sync-server for Santa clients)
 
 ## How to Run (if built from source)
 

--- a/components/AuthorizationManager/interface/DecisionManagerInterface.swift
+++ b/components/AuthorizationManager/interface/DecisionManagerInterface.swift
@@ -13,6 +13,11 @@ public enum DecisionManagerError: Error {
     case invalidConfiguration
 }
 
+public enum DecisionManagerClientMode: Int {
+    case MONITOR
+    case LOCKDOWN
+}
+
 public struct DecisionManagerRequest {
     public var binaryPath: String
     public var codeDirectoryHash: BinaryHash
@@ -24,4 +29,5 @@ public struct DecisionManagerRequest {
 public protocol DecisionManagerInterface {
     func processRequest(request: DecisionManagerRequest,
                         allow: inout Bool) -> Bool
+    func getClientMode() -> DecisionManagerClientMode
 }

--- a/components/LocalDecisionManager/src/LocalDecisionManager.swift
+++ b/components/LocalDecisionManager/src/LocalDecisionManager.swift
@@ -18,9 +18,14 @@ private enum DefaultAction {
 }
 
 private final class LocalDecisionManager: DecisionManagerInterface {
+    func getClientMode() -> DecisionManagerClientMode {
+        return self.clientMode
+    }
+    
     private let logger: LoggerInterface
     private let configuration: ConfigurationInterface
 
+    private let clientMode: DecisionManagerClientMode
     private let defaultAction: DefaultAction
     private let ruleDatabasePath: String
 
@@ -41,6 +46,26 @@ private final class LocalDecisionManager: DecisionManagerInterface {
             configUpdateIntervalOpt = 60
         }
 
+        if let clientMode = configuration.integerValue(moduleName: "LocalDecisionManager",
+                                                      key: "client_mode") {
+            if clientMode == 1 {
+                self.clientMode = .MONITOR
+            }
+            else if clientMode == 2 {
+                self.clientMode = .LOCKDOWN
+            }
+            else {
+                logger.logMessage(severity: LoggerMessageSeverity.error,
+                                  message: "The 'LocalDecisionManager.client_mode' setting is not valid. Allowed values are: 1 (MONITOR) or 2 (LOCKDOWN)")
+
+                throw DecisionManagerError.invalidConfiguration
+            }
+        } else {
+            logger.logMessage(severity: LoggerMessageSeverity.information,
+                              message: "The client_mode setting is missing from the 'LocalDecisionManager' configuration section. Defaulting to MONITOR mode.")
+            self.clientMode = .MONITOR
+        }
+        
         if let ruleDatabasePath = configuration.stringValue(moduleName: "LocalDecisionManager",
                                                             key: "rule_database_path") {
             self.ruleDatabasePath = ruleDatabasePath

--- a/config/config.json
+++ b/config/config.json
@@ -7,12 +7,14 @@
     "server_address": "http://127.0.0.1:8080",
     "update_interval": 10,
     "default_action": "allow",
-    "machine_identifier": "default_1234"
+    "machine_identifier": "default_1234",
+    "client_mode": 1
   },
 
   "LocalDecisionManager": {
     "default_action": "allow",
     "rule_database_path": "/etc/sinter/rules.json",
-    "update_interval": "10"
+    "update_interval": "10",
+    "client_mode": 1
   }
 }


### PR DESCRIPTION
Closes #56 by changing blocking behavior thusly:

The config now allows for a variable called `client_mode` which can be a `1` (MONITOR) or `2` (LOCKDOWN). If missing, Sinter defaults to the MONITOR mode.

LOCKDOWN mode works as before: there are implicit blocking rules like any binary with a missing or invalid signature.

MONITOR mode now works by simply logging these violations, and not blocking execution of any binary.